### PR TITLE
fix: Correct targetPort to 8080 in backend-v1 service manifest

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: backend
     version: v1


### PR DESCRIPTION
This PR fixes the backend-v1 service manifest by changing the targetPort from 8081 to 8080 to match the container port of the backend pod. This resolves connectivity issues from frontend-v1 to backend-v1 caused by port mismatch.