### PR TITLE
Fix backend-v1 service selector typo and targetPort mismatch

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,9 +9,9 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
-    app: bakend
+    app: backend
     version: v1
   type: ClusterIP
 ---


### PR DESCRIPTION
This PR fixes the backend-v1 service manifest by correcting the selector typo from 'app: bakend' to 'app: backend'.
It also updates the targetPort from 8081 to 8080 to correctly match the containerPort defined in the backend-v1 deployment.

These changes will fix the connectivity issue from frontend-v1 to backend-v1 service in the default namespace.