### PR TITLE
Fix backend-v1 service selector typo and port mismatch

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,9 +9,9 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
-    app: bacend
+    app: backend
     version: v1
   type: ClusterIP
 ---


### PR DESCRIPTION
This PR fixes the backend-v1 service to correctly select the backend pods by correcting the app selector label from `bacend` to `backend`. It also fixes the service targetPort from 8081 to 8080 to match the backend containerPort.

These changes should restore connectivity from frontend-v1 to backend-v1 via the backend-v1 service.

Please review and merge to deploy the fix.