### PR TITLE
fix: correct typo in backend-v1 service selector

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -11,7 +11,7 @@ spec:
     protocol: TCP
     targetPort: 8081
   selector:
-    app: bakend
+    app: backend
     version: v1
   type: ClusterIP
 ---


### PR DESCRIPTION
This PR fixes a typo in the selector of the backend-v1 Service manifest. The app label was incorrectly set to 'bakend' instead of 'backend'. This caused the Service to not select any backend pods, breaking connectivity.

- Corrected selector.app from 'bakend' to 'backend' in backend-v1.yaml

This fix will restore proper Service endpoints and connectivity to the backend-v1 pods.