### PR TITLE
fix: Correct typo in backend-v1 service selector labels

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -11,7 +11,7 @@ spec:
     protocol: TCP
     targetPort: 8081
   selector:
-    app: bakend
+    app: backend
     version: v1
   type: ClusterIP
 ---


### PR DESCRIPTION
This PR fixes the issue with the backend-v1 service selector labels where the app label had a typo (`bakend` instead of `backend`). This caused the service to have no endpoints and break connectivity from the frontend.

Changes:
- Corrected the selector label `app` from `bakend` to `backend` in `backend-v1.yaml` service definition.

Please review and merge to restore service connectivity.