### PR TITLE
Fix backend-v1 service targetPort to match pod container port

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: backend
     version: v1


### PR DESCRIPTION
This PR fixes the connectivity issue between frontend-v1 and backend-v1 by correcting the targetPort in backend-v1 Service from 8081 to 8080, which matches the container port in the backend-v1 pods. This ensures the Service correctly routes traffic to the backend-v1 pods.