### PR TITLE
fix: Correct service label 'app' and targetPort in backend-v1 Service

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -4,12 +4,12 @@ metadata:
   name: backend-v1
   namespace: default
   labels:
-    app: bakend
+    app: backend
 spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: backend
     version: v1


### PR DESCRIPTION
This PR fixes two issues in the backend-v1 Service manifest:
1. Corrects the label 'app' from 'bakend' to 'backend' to match the pod labels.
2. Fixes the targetPort from 8081 to 8080 to match the container port.

These fixes resolve the connectivity issue between frontend-v1 and backend-v1 by ensuring the service routes traffic correctly to backend-v1 pods.