### PR TITLE
fix: Correct service selector and targetPort in backend-v1 service

### DIFF
--- a/backend-v1.yaml
+++ b/backend-v1.yaml
@@ -9,9 +9,9 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
-    app: bakend
+    app: backend
     version: v1
   type: ClusterIP
 ---


### PR DESCRIPTION
This PR fixes the connectivity issue between frontend-v1 and backend-v1 by:

- Correcting the selector in backend-v1 service from `app=bakend` to `app=backend` to properly select pods.
- Changing the targetPort in backend-v1 service from 8081 to 8080 to match the container port.

These changes will ensure the backend-v1 service routes traffic correctly to the backend-v1 pods, resolving connection refused errors from frontend-v1.